### PR TITLE
Sort it by anatomy, instead of just by alphabetical

### DIFF
--- a/confu/__init__.py
+++ b/confu/__init__.py
@@ -6,7 +6,7 @@ Helpers for using these infrastructure tools:
 - `ansible <http://docs.ansible.com/>`_
 
 """
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 __all__ = [
     'ansible',


### PR DESCRIPTION
I prefer the render method to show me the template with the keys sorted as cloudformation sorts it.
